### PR TITLE
Github action workflow - version after

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Check Out Repo 
         uses: actions/checkout@v2
-      - name: NPM Increment Version
-        run: npm version --allow-same-version from-git
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -57,3 +57,5 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+      - name: NPM Increment Version
+        run: npm version patch

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -20,6 +20,10 @@ jobs:
     steps:
       - name: Check Out Repo 
         uses: actions/checkout@v2
+        with:
+          ref: 'master'
+      - name: NPM Increment Version
+        run: npm version --allow-same-version from-git
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v3
@@ -57,5 +61,3 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-      - name: NPM Increment Version
-        run: npm version patch


### PR DESCRIPTION
The npm version command was having trouble finding the existing annotated tag even though it was present. Going to change to package.json version after version build is done to prepare for the next release.